### PR TITLE
fix bug in event_callbacks.rb due to renaming of blk to user_blk and current_blk

### DIFF
--- a/lib/buggery/event_callbacks.rb
+++ b/lib/buggery/event_callbacks.rb
@@ -158,7 +158,7 @@ class EventCallbacks < FakeCOM
     )
   end
 
-  def add( cb_hsh, &user_blk )
+  def add( cb_hsh )
     # This actually only changes the corresponding callbacks (Ruby level
     # Proc) in the callback table, and updates the interest mask. The real
     # callback (FFI Function) was already added in initialize.
@@ -168,7 +168,7 @@ class EventCallbacks < FakeCOM
         raise ArgumentError, "#{self.class}:#{__method__}: Invalid callback: #{cb_name}"
       end
       @interest_mask |= MASKS[cb_name]
-      @callback_table[cb_name]=user_blk
+      @callback_table[cb_name]=current_blk
     }
     @debugger.SetEventCallbacks interface_ptr
   end


### PR DESCRIPTION
when you renamed blk to user_blk and current_blk you started using the &user_blk which was unsupported in the new interface instead of the current_blk which was the block from the hash
